### PR TITLE
Default Dates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,16 @@ const creds = {
 
 const costExplorer = new AWS.CostExplorer(creds);
 
+// AWS Cost Explorer API doesn't track data for more than 1 year
+const now = new Date()
+const endDate = now.toISOString().slice(0, 10)
+now.setYear(now.getFullYear() - 1)
+const startDate = now.toISOString().slice(0, 10)
+
 const ceParams = {
-  // Start=2018-08-01,End=2019-05-01
-  TimePeriod: { /* required */
-    Start: '2018-08-01', /* required */
-    End: '2019-05-01' /* required */
+  TimePeriod: {
+    Start: startDate,
+    End: endDate
   },
   Granularity: 'MONTHLY',
   Metrics: [


### PR DESCRIPTION
Until #9 is resolved I thought it would be useful if the tool defaults to the last 12 months of activity instead of having hard coded dates that prevent it from running with an error.

I thought this could be useful since people may try out the utility after a [recent blog post](https://blog.mapbox.com/how-much-carbon-is-your-server-emitting-d7edf3496fd6) by Mapbox which points here.

