### PR TITLE
Ignore non-infrastructure costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ If all goes well, you'll get something like this (sample data below):
 
 There are also flags to let you see a breakdown by service as well.
 
+Note: Only infrastructure costs are taken into consideration. Non-infrastructure global costs like Taxes are ignored.
+
 
 ### Licensing
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,10 @@ const ceParams = {
   }]
 }
 
+const nonInfrastructureCosts = [
+  'Tax', 'AWS Support (Business)'
+]
+
 // give us an awaitable function
 async function getRawCosts() {
   return new Promise(function (resolve, reject) {
@@ -62,10 +66,15 @@ function calculateGreenPortions(costMap) {
 
   const costPerRegion = {};
 
-  for (const [key, value] of costMap.entries()) {
 
+  for (const [key, value] of costMap.entries()) {
+    if (nonInfrastructureCosts.includes(key)) {
+      continue
+    }
     const greenReducer = (accumulator, currentValue) => {
-      if (currentValue.greenRegion) {
+      if (nonInfrastructureCosts.includes(currentValue.service)) {
+        return accumulator
+      } else if (currentValue.greenRegion) {
         return (accumulator + currentValue.blendedCost);
       } else {
         return accumulator;
@@ -73,7 +82,9 @@ function calculateGreenPortions(costMap) {
     };
 
     const grayReducer = (accumulator, currentValue) => {
-     if (!currentValue.greenRegion) {
+      if (nonInfrastructureCosts.includes(currentValue.service)) {
+        return accumulator
+      } else if (!currentValue.greenRegion) {
         return (accumulator + currentValue.blendedCost);
       } else {
         return accumulator;


### PR DESCRIPTION
Proposal for addressing part of https://github.com/thegreenwebfoundation/green-cost-explorer/issues/15

I think focusing on the infrastructure costs would make sense because it's actionable.