### PR TITLE
[WIP] Fetch costs paid for with credits too

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,15 @@ const ceParams = {
     Start: startDate,
     End: endDate
   },
+  // TODO: Test whether this breaks summing if costs are split between credits/cash
+  Filter: {
+    Dimensions: {
+      Key: 'RECORD_TYPE',
+      Values: [
+        'Credit'
+      ],
+    }
+  },
   Granularity: 'MONTHLY',
   Metrics: [
     'BlendedCost',
@@ -47,6 +56,7 @@ async function getRawCosts() {
       if (err) {
         reject(err)
       }
+      console.log(JSON.stringify(data))
       resolve(data)
     })
   })


### PR DESCRIPTION
**ToDos**
- [ ] Test all use cases are covered
	- [x] cost wholly covered by credits: works (see above)
	- [ ] cost wholly covered by cash: think it should work, can't check though, don't have access to a paying AWS account rn
	- [ ] cost blended between cash/credits: I think this would produce faulty results, as the cost is summed, effectively subtracting the credits again

See #26